### PR TITLE
Degrain generateBoard test into smaller tests

### DIFF
--- a/src/game/__tests__/generateBoard.test.ts
+++ b/src/game/__tests__/generateBoard.test.ts
@@ -3,29 +3,27 @@ import { generateBoard } from "../generateBoard";
 describe("Given the generateBoard function", () => {
   describe("When it receives 5", () => {
     const dimensions = 5;
+    const board = generateBoard(dimensions);
 
     test("Then it should return an board of rows with length 5.", () => {
-      const expectedLength = 5;
+      const expectedRowLength = 5;
 
-      const arrayLength = generateBoard(dimensions).length;
+      const rowLength = board.length;
 
-      expect(arrayLength).toBe(expectedLength);
+      expect(rowLength).toBe(expectedRowLength);
     });
 
     test("Then it should return an board of columns with length 5.", () => {
-      const expectedRowLength = 5;
-      const board = generateBoard(dimensions);
+      const expectedColumnLength = 5;
 
       const areAllColumnsCorrectLength = board.every(
-        (row) => row.length === expectedRowLength
+        (row) => row.length === expectedColumnLength
       );
 
       expect(areAllColumnsCorrectLength).toBe(true);
     });
 
     test("Then it should return a board of cells with no mines.", () => {
-      const board = generateBoard(dimensions);
-
       const haveNoMines = board.every((row) =>
         row.every((cell) => cell.hasMine === false)
       );
@@ -34,8 +32,6 @@ describe("Given the generateBoard function", () => {
     });
 
     test("Then it should return a board of cells with no adjacent mines", () => {
-      const board = generateBoard(dimensions);
-
       const haveNoAdjacentMines = board.every((row) =>
         row.every((cell) => cell.adjacentMinesTotal === 0)
       );

--- a/src/game/__tests__/generateBoard.test.ts
+++ b/src/game/__tests__/generateBoard.test.ts
@@ -4,7 +4,7 @@ describe("Given the generateBoard function", () => {
   describe("When it receives 5", () => {
     const dimensions = 5;
 
-    test("Then it should return an board of rows length 5.", () => {
+    test("Then it should return an board of rows with length 5.", () => {
       const expectedLength = 5;
 
       const arrayLength = generateBoard(dimensions).length;

--- a/src/game/__tests__/generateBoard.test.ts
+++ b/src/game/__tests__/generateBoard.test.ts
@@ -2,49 +2,45 @@ import { generateBoard } from "../generateBoard";
 
 describe("Given the generateBoard function", () => {
   describe("When it receives 5", () => {
-    test("Then it should return an array of Cell arrays of length 5 each, with no mines and no adjacent mines", () => {
-      const dimensions = 5;
-      const expectedBoard = [
-        [
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-        ],
-        [
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-        ],
-        [
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-        ],
-        [
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-        ],
-        [
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-          { hasMine: false, adjacentMinesTotal: 0 },
-        ],
-      ];
+    const dimensions = 5;
 
+    test("Then it should return an board of rows length 5.", () => {
+      const expectedLength = 5;
+
+      const arrayLength = generateBoard(dimensions).length;
+
+      expect(arrayLength).toBe(expectedLength);
+    });
+
+    test("Then it should return an board of columns with length 5.", () => {
+      const expectedRowLength = 5;
       const board = generateBoard(dimensions);
 
-      expect(board).toStrictEqual(expectedBoard);
+      const areAllColumnsCorrectLength = board.every(
+        (row) => row.length === expectedRowLength
+      );
+
+      expect(areAllColumnsCorrectLength).toBe(true);
+    });
+
+    test("Then it should return a board of cells with no mines.", () => {
+      const board = generateBoard(dimensions);
+
+      const haveNoMines = board.every((row) =>
+        row.every((cell) => cell.hasMine === false)
+      );
+
+      expect(haveNoMines).toBe(true);
+    });
+
+    test("Then it should return a board of cells with no adjacent mines", () => {
+      const board = generateBoard(dimensions);
+
+      const haveNoAdjacentMines = board.every((row) =>
+        row.every((cell) => cell.adjacentMinesTotal === 0)
+      );
+
+      expect(haveNoAdjacentMines).toBe(true);
     });
   });
 

--- a/src/game/generateBoard.ts
+++ b/src/game/generateBoard.ts
@@ -9,16 +9,16 @@ export const generateBoard = (dimensions: number): Board => {
 
   const board: Board = [];
 
-  for (let row = 0; row < dimensions; row++) {
+  for (let rowNumber = 0; rowNumber < dimensions; rowNumber++) {
     board.push([]);
 
-    for (let column = 0; column < dimensions; column++) {
+    for (let columnNumber = 0; columnNumber < dimensions; columnNumber++) {
       const cell: Cell = {
         hasMine: false,
         adjacentMinesTotal: 0,
       };
 
-      board[row][column] = cell;
+      board[rowNumber][columnNumber] = cell;
     }
   }
 


### PR DESCRIPTION
Separated the first test in generateBoard.test.ts into smaller, separate tests, keeping each test simpler and more readable. Also improved generateBoard.ts variable names.